### PR TITLE
Update vcpkg-configuration.json file baseline for carbonengine to latest

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,7 +7,7 @@
   "registries": [
     {
       "kind": "git",
-      "baseline": "ffb0e70cb67e67f7e74eb5d4e79c2df0e38c0b8e",
+      "baseline": "cb1db8dffeb10affcb460a36d62fff0a45405658",
       "repository": "git@github.com:carbonengine/vcpkg-registry.git",
       "packages": ["python3", 
                    "carbon-*",
@@ -15,8 +15,8 @@
                    "greenlet",
                    "ccp-debug-info",
                    "crashpad",
-				   "fxc",
-				   "granny",
+                   "fxc",
+                   "granny",
                    "zlib",
                    "re2c",
                    "amd-fidelityfx",


### PR DESCRIPTION
- Baseline updated to successfully resolve trinity dependency
- Fixed formatting inside vcpkg-configuration.json file (replaced tabs with spaces)