### PR TITLE
Use HTTPS for the vcpkg registries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
+[submodule "vendor/github.com/microsoft/vcpkg"]
+	path = vendor/github.com/microsoft/vcpkg
+	url = https://github.com/microsoft/vcpkg
 [submodule "vendor/github.com/carbonengine/vcpkg-registry"]
 	path = vendor/github.com/carbonengine/vcpkg-registry
 	url = https://github.com/carbonengine/vcpkg-registry
-[submodule "vendor/github.com/microsoft/vcpkg"]
-	path = vendor/github.com/microsoft/vcpkg
-	url = https://github.com/microsoft/vcpkg/

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,8 +8,8 @@
     {
       "kind": "git",
       "baseline": "cb1db8dffeb10affcb460a36d62fff0a45405658",
-      "repository": "git@github.com:carbonengine/vcpkg-registry.git",
-      "packages": ["python3", 
+      "repository": "https://github.com/carbonengine/vcpkg-registry.git",
+      "packages": ["python3",
                    "carbon-*",
                    "tracy",
                    "greenlet",


### PR DESCRIPTION
For vcpkg, it is much more common to use HTTPS for public registries. Accessing them via SSH isn't always possible, as it requires a key pre-installed.

---

The `.gitmodules` change is a change of no change, but this way it is more like the other repos. I have no problems reverting that part if it is unwanted.


###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.